### PR TITLE
Fix segmentation fault  

### DIFF
--- a/TestCode/utils.py
+++ b/TestCode/utils.py
@@ -44,7 +44,7 @@ def imread(path, is_grayscale=False):
   if is_grayscale:
     return scipy.misc.imread(path, flatten=True).astype(np.float)
   else:
-    return scipy.misc.imread(path).astype(np.float)
+    return np.array(Image.fromarray(scipy.misc.imread(path)).resize((310,230))).astype(np.float)
 
     
 def imsave(image, path):


### PR DESCRIPTION
Fixed #2 
Which will return segmentation error while using high resolution images
Updated utils.py to resize the images which will be the input to the height and width specified in the paper.Changed  imread in utils.py from
`scipy.misc.imread(path).astype(np.float)` 
to
`np.array(Image.fromarray(scipy.misc.imread(path)).resize((310,230))).astype(np.float)`
